### PR TITLE
Chaining method calls more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,53 @@ hs_err_pid*
 
 /ebuild/
 /target/
+
+
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ Enabling simpler microbenchmarks of Java8 and more traditional code.
 
 Often, when developing performance sensitive code, it is convenient to benchmark that code in order to evaluate and improve its performance. UBench is a tool that can help.
 
+##Maven
+
+Maven dependency is available on Maven Central:
+
+    <dependency>
+        <groupId>net.tuis.ubench</groupId>
+        <artifactId>ubench</artifactId>
+        <version>0.0.5</version>
+    </dependency>
+
 ##Example Use Case - Largest Prime Calculator
 
 See the running code in [the test section - net.tuis.ubench.PrimeSieve](https://github.com/rolfl/MicroBench/blob/master/src/test/java/net/tuis/ubench/PrimeSieve.java)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Simply run the code in a UBench task:
 
         UBench bench = new UBench("Simple Performance");
         bench.addIntTask("Prime less than 4000", () -> getMaxPrimeBefore(4000), p -> p == 3989);
-        bench.report("Simple Performance", bench.press(10000));
+        UBench.report("Simple Performance", bench.press(10000));
 
 This will produce (on my machine) the results:
 
@@ -103,7 +103,7 @@ Note that the code is the same as the initial example, but the method name is di
         UBench bench = new UBench("Comparative Performance");
         bench.addIntTask("Primes Filled", () -> getMaxPrimeBefore(4000), p -> p == 3989);
         bench.addIntTask("Primes Negated", () -> getMaxPrimeBeforeNeg(4000), p -> p == 3989);
-        bench.report("Effects of Arrays.fill()", bench.press(10000));
+        UBench.report("Effects of Arrays.fill()", bench.press(10000));
 
 This produces the output:
 
@@ -141,7 +141,7 @@ How does the performance change with different values for the limit? Let's check
             bench.addIntTask("Primes " + limit, () -> getMaxPrimeBefore(limit), p -> p == check);
         }
         
-        bench.report("Prime Scalability", bench.press(UMode.SEQUENTIAL, 10000));
+        UBench.report("Prime Scalability", bench.press(UMode.SEQUENTIAL, 10000));
 
 We run the code and get the results:
 

--- a/src/main/java/net/tuis/ubench/UBench.java
+++ b/src/main/java/net/tuis/ubench/UBench.java
@@ -437,7 +437,7 @@ public final class UBench {
      * @param stats
      *            the UStats data to report
      */
-    public void report(String title, List<UStats> stats) {
+    public static void report(String title, List<UStats> stats) {
         report(title, stats, null);
     }
 
@@ -453,7 +453,7 @@ public final class UBench {
      *            the Comparator to sort the UStats by (see class constants for
      *            some useful suggestions)
      */
-    public void report(String title, List<UStats> stats, Comparator<UStats> comparator) {
+    public static void report(String title, List<UStats> stats, Comparator<UStats> comparator) {
 
         if (title != null) {
             System.out.println(title);

--- a/src/main/java/net/tuis/ubench/UBench.java
+++ b/src/main/java/net/tuis/ubench/UBench.java
@@ -139,10 +139,11 @@ public final class UBench {
         this.suiteName = suiteName;
     }
 
-    private void putTask(String name, Task t) {
+    private UBench putTask(String name, Task t) {
         synchronized (tasks) {
             tasks.put(name, t);
         }
+        return this;
     }
 
     /**
@@ -158,9 +159,10 @@ public final class UBench {
      *            The task to perform
      * @param check
      *            The check of the results from the task.
+     * @return The same object, for chaining calls.
      */
-    public <T> void addTask(String name, Supplier<T> task, Predicate<T> check) {
-        putTask(name, () -> {
+    public <T> UBench addTask(String name, Supplier<T> task, Predicate<T> check) {
+        return putTask(name, () -> {
             long start = System.nanoTime();
             T result = task.get();
             long time = System.nanoTime() - start;
@@ -181,9 +183,11 @@ public final class UBench {
      *            allowed.
      * @param task
      *            The task to perform
+     *
+     * @return The same object, for chaining calls.
      */
-    public <T> void addTask(String name, Supplier<T> task) {
-        addTask(name, task, null);
+    public <T> UBench addTask(String name, Supplier<T> task) {
+        return addTask(name, task, null);
     }
 
     /**
@@ -197,9 +201,10 @@ public final class UBench {
      *            The task to perform
      * @param check
      *            The check of the results from the task.
+     * @return The same object, for chaining calls.
      */
-    public void addIntTask(String name, IntSupplier task, IntPredicate check) {
-        putTask(name, () -> {
+    public UBench addIntTask(String name, IntSupplier task, IntPredicate check) {
+        return putTask(name, () -> {
             long start = System.nanoTime();
             int result = task.getAsInt();
             long time = System.nanoTime() - start;
@@ -218,10 +223,10 @@ public final class UBench {
      *            allowed.
      * @param task
      *            The task to perform
+     * @return The same object, for chaining calls.
      */
-
-    public void addIntTask(String name, IntSupplier task) {
-        addIntTask(name, task, null);
+    public UBench addIntTask(String name, IntSupplier task) {
+        return addIntTask(name, task, null);
     }
 
     /**
@@ -235,9 +240,10 @@ public final class UBench {
      *            The task to perform
      * @param check
      *            The check of the results from the task.
+     * @return The same object, for chaining calls.
      */
-    public void addLongTask(String name, LongSupplier task, LongPredicate check) {
-        putTask(name, () -> {
+    public UBench addLongTask(String name, LongSupplier task, LongPredicate check) {
+        return putTask(name, () -> {
             long start = System.nanoTime();
             long result = task.getAsLong();
             long time = System.nanoTime() - start;
@@ -256,9 +262,10 @@ public final class UBench {
      *            allowed.
      * @param task
      *            The task to perform
+     * @return The same object, for chaining calls.
      */
-    public void addLongTask(String name, LongSupplier task) {
-        addLongTask(name, task, null);
+    public UBench addLongTask(String name, LongSupplier task) {
+        return addLongTask(name, task, null);
     }
 
     /**
@@ -272,9 +279,10 @@ public final class UBench {
      *            The task to perform
      * @param check
      *            The check of the results from the task.
+     * @return The same object, for chaining calls.
      */
-    public void addDoubleTask(String name, DoubleSupplier task, DoublePredicate check) {
-        putTask(name, () -> {
+    public UBench addDoubleTask(String name, DoubleSupplier task, DoublePredicate check) {
+        return putTask(name, () -> {
             long start = System.nanoTime();
             double result = task.getAsDouble();
             long time = System.nanoTime() - start;
@@ -293,9 +301,10 @@ public final class UBench {
      *            allowed.
      * @param task
      *            The task to perform
+     * @return The same object, for chaining calls.
      */
-    public void addDoubleTask(String name, DoubleSupplier task) {
-        addDoubleTask(name, task, null);
+    public UBench addDoubleTask(String name, DoubleSupplier task) {
+        return addDoubleTask(name, task, null);
     }
 
     /**

--- a/src/test/java/net/tuis/ubench/ExampleCode.java
+++ b/src/test/java/net/tuis/ubench/ExampleCode.java
@@ -50,10 +50,10 @@ public class ExampleCode {
         bench.addIntTask("Traditional alphas", () -> countDistinctChars(testdata), g -> g == 63);
         bench.addIntTask("Traditional hello", () -> countDistinctChars(hello), g -> g == 9);
 
-        bench.report("Warmup", bench.press(100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
-        bench.report("Sequential", bench.press(UMode.SEQUENTIAL, 100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
-        bench.report("Parallel", bench.press(UMode.PARALLEL, 100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
-        bench.report("Interleaved", bench.press(UMode.INTERLEAVED, 100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
+        UBench.report("Warmup", bench.press(100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
+        UBench.report("Sequential", bench.press(UMode.SEQUENTIAL, 100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
+        UBench.report("Parallel", bench.press(UMode.PARALLEL, 100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
+        UBench.report("Interleaved", bench.press(UMode.INTERLEAVED, 100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
 
     }
 

--- a/src/test/java/net/tuis/ubench/ExampleCode.java
+++ b/src/test/java/net/tuis/ubench/ExampleCode.java
@@ -42,13 +42,12 @@ public class ExampleCode {
         final String testdata = "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789";
         final String hello = "Hello World!";
 
-        UBench bench = new UBench("distinct chars");
+        UBench bench = new UBench("distinct chars")
+            .addIntTask("Functional alphas", () -> charcount.applyAsInt(testdata), g -> g == 63)
+            .addIntTask("Functional hello", () -> charcount.applyAsInt(hello), g -> g == 9)
 
-        bench.addIntTask("Functional alphas", () -> charcount.applyAsInt(testdata), g -> g == 63);
-        bench.addIntTask("Functional hello", () -> charcount.applyAsInt(hello), g -> g == 9);
-
-        bench.addIntTask("Traditional alphas", () -> countDistinctChars(testdata), g -> g == 63);
-        bench.addIntTask("Traditional hello", () -> countDistinctChars(hello), g -> g == 9);
+            .addIntTask("Traditional alphas", () -> countDistinctChars(testdata), g -> g == 63)
+            .addIntTask("Traditional hello", () -> countDistinctChars(hello), g -> g == 9);
 
         UBench.report("Warmup", bench.press(100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));
         UBench.report("Sequential", bench.press(UMode.SEQUENTIAL, 100000, 1000, 10.0, 500, TimeUnit.MILLISECONDS));

--- a/src/test/java/net/tuis/ubench/PrimeSieve.java
+++ b/src/test/java/net/tuis/ubench/PrimeSieve.java
@@ -47,13 +47,13 @@ public class PrimeSieve {
     private static void benchSimple() {
         UBench bench = new UBench("Simple Performance");
         bench.addIntTask("Prime less than 4000", () -> getMaxPrimeBefore(4000), p -> p == 3989);
-        bench.report("Simple Performance", bench.press(10000));
+        UBench.report("Simple Performance", bench.press(10000));
     }
 
     private static void benchSimpleNeg() {
         UBench bench = new UBench("Negate Performance");
         bench.addIntTask("Prime less than 4000", () -> getMaxPrimeBeforeNeg(4000), p -> p == 3989);
-        bench.report("Negated Performance", bench.press(10000));
+        UBench.report("Negated Performance", bench.press(10000));
     }
 
     private static void benchCompare() {
@@ -62,7 +62,7 @@ public class PrimeSieve {
         bench.addIntTask("Primes Filled", () -> getMaxPrimeBefore(4000), p -> p == 3989);
         bench.addIntTask("Primes Negated", () -> getMaxPrimeBeforeNeg(4000), p -> p == 3989);
         
-        bench.report("Effects of Arrays.fill()", bench.press(10000));
+        UBench.report("Effects of Arrays.fill()", bench.press(10000));
     }
 
     private static void benchScale() {
@@ -77,7 +77,7 @@ public class PrimeSieve {
             bench.addIntTask("Primes " + limit, () -> getMaxPrimeBefore(limit), p -> p == check);
         }
         
-        bench.report("Prime Scalability", bench.press(UMode.SEQUENTIAL, 10000));
+        UBench.report("Prime Scalability", bench.press(UMode.SEQUENTIAL, 10000));
     }
 
     public static void main(String[] args) {

--- a/src/test/java/net/tuis/ubench/RandomSorter.java
+++ b/src/test/java/net/tuis/ubench/RandomSorter.java
@@ -26,10 +26,10 @@ public class RandomSorter {
             return copy;
         };
         
-        UBench bench = new UBench("Sort Algorithms");
-        bench.addTask("Functional", stream, validate);
-        bench.addTask("Traditional", trad, validate);
-        UBench.report("With Warmup", bench.press(10000));
+        UBench.report("With Warmup", new UBench("Sort Algorithms")
+            .addTask("Functional", stream, validate)
+            .addTask("Traditional", trad, validate)
+            .press(10000));
         
     }
 

--- a/src/test/java/net/tuis/ubench/RandomSorter.java
+++ b/src/test/java/net/tuis/ubench/RandomSorter.java
@@ -29,7 +29,7 @@ public class RandomSorter {
         UBench bench = new UBench("Sort Algorithms");
         bench.addTask("Functional", stream, validate);
         bench.addTask("Traditional", trad, validate);
-        bench.report("With Warmup", bench.press(10000));
+        UBench.report("With Warmup", bench.press(10000));
         
     }
 


### PR DESCRIPTION
Made it easier to use UBench by chaining methods. Existing code will not break, but will cause a warning as the `report` method has changed from non-static to static.
